### PR TITLE
remove import of random, not actually used

### DIFF
--- a/americanflag.py
+++ b/americanflag.py
@@ -1,6 +1,5 @@
     
 import turtle
-import random
 
 
 ### this function is drawn filling colors in the flag ### 


### PR DESCRIPTION
Hello,

You're not actually calling any functions from the python module 'random' for americanflag.py, which makes the import unnecessary. Please remove.


